### PR TITLE
WIP

### DIFF
--- a/config/spapi.php
+++ b/config/spapi.php
@@ -1,6 +1,8 @@
 <?php
 
 return [
+    'registration_enbaled' => env('SPAPI_REGISTRATION_ENABLED', true),
+
     'installation_type' => 'single',
 
     'aws' => [

--- a/config/spapi.php
+++ b/config/spapi.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'registration_enbaled' => env('SPAPI_REGISTRATION_ENABLED', true),
+    'registration_enabled' => env('SPAPI_REGISTRATION_ENABLED', true),
 
     'installation_type' => 'single',
 

--- a/src/SellingPartnerApi.php
+++ b/src/SellingPartnerApi.php
@@ -50,9 +50,6 @@ final class SellingPartnerApi
      */
     public static function regionToEndpoint(string $region): array
     {
-        if (!in_array($region, static::REGIONS)) {
-            throw new InvalidArgumentException("Invalid SP API region: $region");
-        }
         return constant('SellingPartnerApi\Endpoint::' . $region);
     }
 }

--- a/src/SellingPartnerApiServiceProvider.php
+++ b/src/SellingPartnerApiServiceProvider.php
@@ -10,7 +10,7 @@ use SellingPartnerApi\Endpoint;
 
 class SellingPartnerApiServiceProvider extends ServiceProvider implements DeferrableProvider
 {
-    private $apiClasses;
+    private array $apiClasses;
 
     /**
      * Bootstrap the application events.


### PR DESCRIPTION
Hi,

this PR addresses some issues discussed in #2 and #3.

I decided against caching the classes and against putting the class finding logic in the config as well. I think having the service provider implement the DeferrableProvider interface as is, is already enough to reduce the performance impact in production environments. I had previously overlooked this. 
I could verify that when the DeferrableProvider interface is added, the ServiceProvider is neither created nor registered or booted on normal HTTP requests. Also a robust caching mechanism which ensures that the classes are up to date at all times is not that simple to implement. 

I would vote for listing all the API classes explicitly as well. The auto-discovery "feature" does not provide any benefit for the user, but has a high risk of doing harm. It only saves the package maintainer a few minutes ;)

I also removed the region check to be able to use EU_SANDBOX during tests. I still don't really see why this check is needed except because the region db column for the multiseller setup is defined like this:
```
$table->enum('region', SellingPartnerApi::REGIONS);
```
If we changed this, we could probably remove the REGIONS constant  in SellingPartnerApi (`public const REGIONS = ['NA', 'EU', 'FE'];`) completely.